### PR TITLE
Correct desktop build failure - Jessy updates missing (LTS support ended)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ HINT = ryft-server
 APP_VERSION ?= latest
 RYFT_DOCKER_BRANCH ?= master
 RYFT_INTEGRATION_TEST ?= develop
+GOCACHE ?= off
 
 all: build caggs version
 
@@ -44,6 +45,8 @@ ${GOPATH}/bin/govendor:
 .PHONY: build install
 build: update_vendor update_bindata
 	@echo "[${HINT}]: building ryft-server..."
+	@whoami
+	@go env GOCACHE
 	@go build -ldflags "-s -w -X main.Version=${VERSION} -X main.GitHash=${GITHASH}" -tags "${GO_TAGS}"
 install: update_vendor update_bindata
 	@echo "[${HINT}]: installing ryft-server..."

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ HINT = ryft-server
 APP_VERSION ?= latest
 RYFT_DOCKER_BRANCH ?= master
 RYFT_INTEGRATION_TEST ?= develop
-GOCACHE ?= off
 
 all: build caggs version
 
@@ -45,8 +44,6 @@ ${GOPATH}/bin/govendor:
 .PHONY: build install
 build: update_vendor update_bindata
 	@echo "[${HINT}]: building ryft-server..."
-	@whoami
-	@go env GOCACHE
 	@go build -ldflags "-s -w -X main.Version=${VERSION} -X main.GitHash=${GITHASH}" -tags "${GO_TAGS}"
 install: update_vendor update_bindata
 	@echo "[${HINT}]: installing ryft-server..."

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,8 @@
 HINT = ryft-server/docker
 
 SOURCE ?= $(abspath $(dir ${CURDIR}))
-BUILD_IMAGE_TAG ?= latest
+#BUILD_IMAGE_TAG ?= latest
+BUILD_IMAGE_TAG ?= v1 
 
 all: debian
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -19,10 +19,8 @@ build: image
 
 # build Debian package
 debian: build
-	@echo "[${HINT}]: building Debian package (as ryftuser)..."
+	@echo "[${HINT}]: building Debian package (as root)..."
 	docker run --rm \
-		--user $(shell id -u ${USER}):$(shell id -g ${USER}) \
-		-v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
 		-v ${SOURCE}:/go/src/github.com/getryft/ryft-server \
 		ryft/server/build:${BUILD_IMAGE_TAG} make -C debian all
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,7 +2,7 @@ HINT = ryft-server/docker
 
 SOURCE ?= $(abspath $(dir ${CURDIR}))
 #BUILD_IMAGE_TAG ?= latest
-BUILD_IMAGE_TAG ?= v1 
+BUILD_IMAGE_TAG ?= $(shell whoami) 
 
 all: debian
 
@@ -45,7 +45,7 @@ cli: image
 # create image to build sources
 image: debtorpm
 	@echo "[${HINT}]: building Docker image..."
-	docker build -q -t=ryft/server/build:${BUILD_IMAGE_TAG} build
+	docker build -q -t=ryft/server/build:${BUILD_IMAGE_TAG} --build-arg BUILD_HOMEDIR=$(shell grep `whoami` /etc/passwd|cut -d':' -f6) build
 
 debtorpm: 
 	@echo "[${HINT}]: building debtorpm Docker image..."

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,7 +1,6 @@
 HINT = ryft-server/docker
 
 SOURCE ?= $(abspath $(dir ${CURDIR}))
-#BUILD_IMAGE_TAG ?= latest
 BUILD_IMAGE_TAG ?= $(shell whoami) 
 
 all: debian
@@ -13,15 +12,18 @@ all: debian
 # update vendor and build as $USER, not as root
 build: image 
 	@echo "[${HINT}]: building ryft-server (as ${USER})..."
-	docker run --rm --user $(shell id -u ${USER}):$(shell id -g ${USER}) \
+	docker run --rm \
+		--user $(shell id -u ${USER}):$(shell id -g ${USER}) \
 		-v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
 		-v ${SOURCE}:/go/src/github.com/getryft/ryft-server \
 		ryft/server/build:${BUILD_IMAGE_TAG} make all
 
 # build Debian package
 debian: build
-	@echo "[${HINT}]: building Debian package (as root)..."
+	@echo "[${HINT}]: building Debian package (as ${USER})..."
 	docker run --rm \
+	        --user $(shell id -u ${USER}):$(shell id -g ${USER}) \
+		-v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
 		-v ${SOURCE}:/go/src/github.com/getryft/ryft-server \
 		ryft/server/build:${BUILD_IMAGE_TAG} make -C debian all
 
@@ -37,7 +39,8 @@ rpm: debian
 # run as $USER, not as root
 cli: image
 	@echo "[${HINT}]: running CLI (as ${USER})..."
-	docker run --rm -it --user $(shell id -u ${USER}):$(shell id -g ${USER}) \
+	docker run --rm -it \
+		--user $(shell id -u ${USER}):$(shell id -g ${USER}) \
 		-v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
 		-v ${SOURCE}:/go/src/github.com/getryft/ryft-server \
 		ryft/server/build:${BUILD_IMAGE_TAG} /bin/bash

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -19,8 +19,10 @@ build: image
 
 # build Debian package
 debian: build
-	@echo "[${HINT}]: building Debian package (as root)..."
+	@echo "[${HINT}]: building Debian package (as ryftuser)..."
 	docker run --rm \
+		--user $(shell id -u ${USER}):$(shell id -g ${USER}) \
+		-v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
 		-v ${SOURCE}:/go/src/github.com/getryft/ryft-server \
 		ryft/server/build:${BUILD_IMAGE_TAG} make -C debian all
 

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -16,7 +16,5 @@ RUN go get -u github.com/kardianos/govendor
 RUN mkdir /home/ryftuser
 RUN chmod 777 /home/ryftuser
 
-USER ryftuser
-
 ENTRYPOINT [ ]
 CMD [ "make", "debian" ]

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -14,6 +14,7 @@ RUN go get -u github.com/jteeuwen/go-bindata/...
 RUN go get -u github.com/kardianos/govendor
 
 RUN mkdir /home/ryftuser
+
 RUN chmod 777 /home/ryftuser
 
 ENTRYPOINT [ ]

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -2,6 +2,8 @@
 #FROM golang:1.8.5
 FROM golang:1.12.1
 
+ARG BUILD_HOMEDIR=/var/lib/jenkins
+
 RUN apt-get update && apt-get install -y git dpkg
 
 # predefined source path
@@ -13,14 +15,8 @@ WORKDIR ${RYFTPATH}
 RUN go get -u github.com/jteeuwen/go-bindata/...
 RUN go get -u github.com/kardianos/govendor
 
-RUN mkdir /home/ryftuser
-RUN chmod 777 /home/ryftuser
-
-RUN mkdir /home/jenkins
-RUN chmod 777 /home/jenkins
-
-RUN mkdir -p /var/lib/jenkins
-RUN chmod 777 /var/lib/jenkins
+RUN mkdir -p ${BUILD_HOMEDIR}
+RUN chmod 777 ${BUILD_HOMEDIR}
 
 ENTRYPOINT [ ]
 CMD [ "make", "debian" ]

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,5 +1,9 @@
 # do not use alpine because it uses incompatible libc!
+
+#build stopped working when jessie stopped LTS update support
 #FROM golang:1.8.5
+
+#BUILD_HOMEDIR workaround addresses golang:1.12.1 issue where non-root user tries to create ~/.cache directory 
 FROM golang:1.12.1
 
 ARG BUILD_HOMEDIR=/var/lib/jenkins

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,5 +1,6 @@
 # do not use alpine because it uses incompatible libc!
-FROM golang:1.8.5
+#FROM golang:1.8.5
+FROM golang:1.12.1
 
 RUN apt-get update && apt-get install -y git dpkg
 
@@ -11,6 +12,11 @@ WORKDIR ${RYFTPATH}
 # main dependencies
 RUN go get -u github.com/jteeuwen/go-bindata/...
 RUN go get -u github.com/kardianos/govendor
+
+RUN mkdir /home/ryftuser
+RUN chmod 777 /home/ryftuser
+
+USER ryftuser
 
 ENTRYPOINT [ ]
 CMD [ "make", "debian" ]

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -15,8 +15,12 @@ RUN go get -u github.com/kardianos/govendor
 
 RUN mkdir /home/ryftuser
 RUN chmod 777 /home/ryftuser
+
 RUN mkdir /home/jenkins
 RUN chmod 777 /home/jenkins
+
+RUN mkdir -p /var/lib/jenkins
+RUN chmod 777 /var/lib/jenkins
 
 ENTRYPOINT [ ]
 CMD [ "make", "debian" ]

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -14,8 +14,9 @@ RUN go get -u github.com/jteeuwen/go-bindata/...
 RUN go get -u github.com/kardianos/govendor
 
 RUN mkdir /home/ryftuser
-
 RUN chmod 777 /home/ryftuser
+RUN mkdir /home/jenkins
+RUN chmod 777 /home/jenkins
 
 ENTRYPOINT [ ]
 CMD [ "make", "debian" ]


### PR DESCRIPTION
desktop build fails due to no jessy-updates in long term support.
Upgrade golang docker, address non-root user defect by adding BUILD_HOMEDIR
